### PR TITLE
allows for optionally disabling soft states for the amp video widget

### DIFF
--- a/src/amp.ui/widget-video.js
+++ b/src/amp.ui/widget-video.js
@@ -11,7 +11,8 @@
             pauseOnHide: true,
             controls:true,
             nativeControlsForTouch:true,
-            plugins:{}
+            plugins:{},
+            enableSoftStates: true
         },
         _states: {
             stopped:0,
@@ -82,7 +83,7 @@
                     self.state(self._states.playing);
 
                 this.on("play", function (e) {
-                    if (!self.softPlay) {
+                    if (!self.softPlay || !self.options.enableSoftStates) {
                         self.state(self._states.playing);
                         self._track("play", {event:e,player:this,time: this.currentTime(),duration: self.duration});
                     } else {
@@ -108,7 +109,7 @@
 
                 this.on("seeking", function (e) {
                     if (!self.softSeek) {
-                        if (self.state() != self._states.paused && e.target.currentTime != 0)
+                        if (self.state() !== self._states.paused && e.target.currentTime !== 0 && self.options.enableSoftStates)
                             self.softPlay = true;
                         self._track("seeked", {event:e,player:this,time: this.currentTime(),duration: self.duration});
                     } else {


### PR DESCRIPTION
`ampVideo` allows for "soft states" to be ignored and not tracked, for example, when a video is set to loop it will not raise another play event on the second loop.

However, depending on your usage of `ampVideo` it is possible to get the viewer into a condition where states are not being tracked (as they are interpretted as soft) and so the player doesn't reflect the state you anticipate.  By disabling soft states, you will receive more notifications, but also always get the correct state information.

This has been made an option so as not to affect any viewers that already use the widget in the current way (ie. with soft states)
